### PR TITLE
Re-index array to remove missing values

### DIFF
--- a/src/ElasticSearch/EloquentHitsIteratorAggregate.php
+++ b/src/ElasticSearch/EloquentHitsIteratorAggregate.php
@@ -70,6 +70,7 @@ final class EloquentHitsIteratorAggregate implements \IteratorAggregate
 
                 return isset($models[$key]) ? $models[$key] : null;
             })->filter()->all();
+            $hits = array_values($hits);
         }
 
         return new \ArrayIterator($hits);


### PR DESCRIPTION
https://app.clubhouse.io/workvivo/story/10548/nike-searching-for-teams-is-throwing-error-message

If elasticsearch was out of sync with the DB (records manually deleted from the DB in this case) it would result in records being corrupted in the JSON response. Leading to an error on the frontend, depending on what JSON format it was expecting.

The issue looks like it was caused by the pagination not being able to process an array that was missing indexes i.e. not sequential from 0 to n. Solution is to simply re-index the array. 